### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/C8338Soner/REACT-FORMS/security/code-scanning/1](https://github.com/C8338Soner/REACT-FORMS/security/code-scanning/1)

In general, the problem is fixed by adding an explicit `permissions` block to the job (or workflow root) that currently lacks one, granting only the minimal privileges required. For this workflow, the `build` job only checks out code, sets up Node, installs dependencies, and runs tests; it does not publish or modify repository state, so it only needs read access to repository contents.

The best targeted fix without changing existing functionality is: in `.github/workflows/npm-publish-github-packages.yml`, under `jobs: build:`, add a `permissions:` section that sets `contents: read`. This confines the `GITHUB_TOKEN` for the `build` job to read-only repository contents while leaving the existing, more permissive `permissions` for `publish-gpr` unchanged. No imports, methods, or additional definitions are needed since this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
